### PR TITLE
Add non-editable install test to CI; test py39 instead of py38

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,9 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: [3.6, 3.8]
+        python-version: [3.6, 3.9]
         backend: ['django']
+        editable_install_option: ['-e', '']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -31,7 +32,7 @@ jobs:
     - name: Install python dependencies
       run: |
         pip install --upgrade pip
-        pip install -e .[testing]
+        pip install ${{ matrix.editable_install_option }} .[testing]
         reentry scan -r aiida
 
     - name: Run test suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
         python-version: [3.6, 3.9]
         backend: ['django']
         editable_install_option: ['-e', '']
+        exclude:
+        - python-version: 3.6
+          editable_install_option: ''
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Fixes #39.

Adds two variants of the 'tests' job in CI, installed with and without the '-e' option. 

Also replaces py38 with py39 as 'upper' Python version to test.

We can merge with admin privileges and then update the "required" checks.