### PR TITLE
`mock-code`: Allow paths to be relative to the config file

### DIFF
--- a/aiida_testing/_config.py
+++ b/aiida_testing/_config.py
@@ -13,6 +13,7 @@ from voluptuous import Schema
 import yaml
 
 CONFIG_FILE_NAME = '.aiida-testing-config.yml'
+CONFIG_FILE_PATH_ENTRY = 'file_path'
 
 
 class ConfigActions(Enum):
@@ -52,6 +53,7 @@ class Config(collections.abc.MutableMapping):
             if config_file_path.exists():
                 with open(config_file_path, encoding='utf8') as config_file:
                     config = yaml.load(config_file, Loader=yaml.SafeLoader)
+                    config[CONFIG_FILE_PATH_ENTRY] = config_file_path
                     break
         else:
             config = {}
@@ -68,8 +70,10 @@ class Config(collections.abc.MutableMapping):
         cwd = pathlib.Path(os.getcwd())
         config_file_path = (cwd / CONFIG_FILE_NAME)
 
+        _dict = self._dict.copy()
+        _dict.pop(CONFIG_FILE_PATH_ENTRY)
         with open(config_file_path, 'w', encoding='utf8') as handle:
-            yaml.dump(self._dict, handle, Dumper=yaml.SafeDumper)
+            yaml.dump(_dict, handle, Dumper=yaml.SafeDumper)
 
     def __getitem__(self, item):
         return self._dict.__getitem__(item)

--- a/aiida_testing/_config.py
+++ b/aiida_testing/_config.py
@@ -28,7 +28,7 @@ class ConfigActions(Enum):
 class Config(collections.abc.MutableMapping):
     """Configuration of aiida-testing package."""
 
-    schema = Schema({'mock_code': Schema({str: str}), 'file-path': str})
+    schema = Schema({'mock_code': Schema({str: str}), 'file-path': pathlib.Path})
 
     def __init__(self, config=None):
         self._dict = config or {}

--- a/aiida_testing/_config.py
+++ b/aiida_testing/_config.py
@@ -13,7 +13,7 @@ from voluptuous import Schema
 import yaml
 
 CONFIG_FILE_NAME = '.aiida-testing-config.yml'
-CONFIG_FILE_PATH_ENTRY = 'file_path'
+CONFIG_FILE_PATH_ENTRY = 'file-path'
 
 
 class ConfigActions(Enum):
@@ -28,7 +28,7 @@ class ConfigActions(Enum):
 class Config(collections.abc.MutableMapping):
     """Configuration of aiida-testing package."""
 
-    schema = Schema({'mock_code': Schema({str: str})})
+    schema = Schema({'mock_code': Schema({str: str}), 'file-path': str})
 
     def __init__(self, config=None):
         self._dict = config or {}

--- a/aiida_testing/mock_code/_fixtures.py
+++ b/aiida_testing/mock_code/_fixtures.py
@@ -10,6 +10,7 @@ import pathlib
 import typing as ty
 import warnings
 import collections
+import os
 
 import click
 import pytest
@@ -17,7 +18,7 @@ import pytest
 from aiida.orm import Code
 
 from ._env_keys import EnvKeys
-from .._config import Config, CONFIG_FILE_NAME, ConfigActions
+from .._config import Config, CONFIG_FILE_NAME, CONFIG_FILE_PATH_ENTRY, ConfigActions
 
 __all__ = (
     "pytest_addoption",
@@ -172,6 +173,10 @@ def mock_code_factory(
             code_executable_path = shutil.which(executable_name) or 'NOT_FOUND'
         if _config_action == ConfigActions.GENERATE.value:
             mock_code_config[label] = code_executable_path
+        if code_executable_path not in ('TO_SPECIFY', 'NOT_FOUND') and \
+            not pathlib.Path(code_executable_path).is_absolute():
+            code_executable_path = mock_code_config.get(CONFIG_FILE_PATH_ENTRY, 'NOT_FOUND') / code_executable_path
+            code_executable_path = os.fspath(code_executable_path)
 
         code = Code(
             input_plugin_name=entry_point,

--- a/aiida_testing/mock_code/_fixtures.py
+++ b/aiida_testing/mock_code/_fixtures.py
@@ -175,7 +175,9 @@ def mock_code_factory(
             mock_code_config[label] = code_executable_path
         if code_executable_path not in ('TO_SPECIFY', 'NOT_FOUND') and \
             not pathlib.Path(code_executable_path).is_absolute():
-            code_executable_path = mock_code_config.get(CONFIG_FILE_PATH_ENTRY, 'NOT_FOUND') / code_executable_path
+            code_executable_path = mock_code_config.get(
+                CONFIG_FILE_PATH_ENTRY, 'NOT_FOUND'
+            ) / code_executable_path
             code_executable_path = os.fspath(code_executable_path)
 
         code = Code(

--- a/aiida_testing/mock_code/_fixtures.py
+++ b/aiida_testing/mock_code/_fixtures.py
@@ -18,7 +18,7 @@ import pytest
 from aiida.orm import Code
 
 from ._env_keys import EnvKeys
-from .._config import Config, CONFIG_FILE_NAME, CONFIG_FILE_PATH_ENTRY, ConfigActions
+from .._config import Config, CONFIG_FILE_NAME, ConfigActions
 
 __all__ = (
     "pytest_addoption",
@@ -96,7 +96,7 @@ def mock_code_factory(
         ignore_files: ty.Iterable[str] = ('_aiidasubmit.sh', ),
         ignore_paths: ty.Iterable[str] = ('_aiidasubmit.sh', ),
         executable_name: str = '',
-        _config: dict = testing_config,
+        _config: Config = testing_config,
         _config_action: str = testing_config_action,
         _regenerate_test_data: bool = mock_regenerate_test_data,
     ):  # pylint: disable=too-many-arguments
@@ -175,10 +175,7 @@ def mock_code_factory(
             mock_code_config[label] = code_executable_path
         if code_executable_path not in ('TO_SPECIFY', 'NOT_FOUND') and \
             not pathlib.Path(code_executable_path).is_absolute():
-            code_executable_path = mock_code_config.get(
-                CONFIG_FILE_PATH_ENTRY, 'NOT_FOUND'
-            ) / code_executable_path
-            code_executable_path = os.fspath(code_executable_path)
+            code_executable_path = os.fspath(_config.file_path / code_executable_path)
 
         code = Code(
             input_plugin_name=entry_point,


### PR DESCRIPTION
See #51 

This PR allows paths in the `.aiida-testing-config.yml` file to be relative. These are interpreted to be relative to the config file location, since the location of the test execution can vary.

I followed the suggestion in the issue above and added the file path as a special key to the config, which is excluded when writing the config out. Another possibility would be to add the filepath as an attribute/property to the `Config` class. I don't have a preference for either way