### PR TITLE
Update aiida-core requirement to allow aiida-core 2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
         backend: ['psql_dos']
         editable_install_option: ['-e', '']
         include:
+        #Test for aiida-core 1.X (since aiida-core 2.X does not support python 3.7)
         - python-version: '3.7'
           backend: 'django'
           editable_install_option: '-e'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,13 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: [3.7, 3.9]
-        backend: ['django']
+        python-version: ['3.9', '3.10']
+        backend: ['psql_dos']
         editable_install_option: ['-e', '']
-        exclude:
-        - python-version: 3.7
-          editable_install_option: ''
+        include:
+        - python-version: '3.7'
+          backend: 'django'
+          editable_install_option: '-e'
 
     services:
       postgres:
@@ -46,7 +47,7 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install ${{ matrix.editable_install_option }} .[testing]
-        reentry scan -r aiida
+        reentry scan -r aiida || true
 
     - name: Run test suite
       env:
@@ -70,7 +71,7 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install -e .[docs]
-        reentry scan -r aiida
+        reentry scan -r aiida || true
     - name: Build docs
       run: cd docs && make
 
@@ -87,7 +88,7 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install -e .[pre_commit,docs,testing]
-        reentry scan -r aiida
+        reentry scan -r aiida || true
     - name: Run pre-commit
       run: |
         pre-commit install

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,8 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering :: Physics
     Framework :: AiiDA
     Framework :: Pytest
@@ -30,7 +32,7 @@ classifiers =
 python_requires = >=3.6
 include_package_data = true
 install_requires =
-    aiida-core>=1.0.0,<2.0.0
+    aiida-core>=1.0.0,<3.0.0
     pytest>=3.6
     voluptuous~=0.12
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ classifiers =
     Environment :: Plugins
     Intended Audience :: Science/Research
     License :: OSI Approved :: MIT License
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -29,7 +28,7 @@ classifiers =
     Framework :: Pytest
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 include_package_data = true
 install_requires =
     aiida-core>=1.0.0,<3.0.0


### PR DESCRIPTION
Since `reentry` is not installed for aiida-core 2.0 these errors are ignored in the CI