### PR TITLE
fix: remove backend specification from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,19 +10,17 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10']
-        backend: ['psql_dos']
         editable_install_option: ['-e', '']
         include:
         #Test for aiida-core 1.X (since aiida-core 2.X does not support python 3.7)
         - python-version: '3.7'
-          backend: 'django'
           editable_install_option: '-e'
 
     services:
       postgres:
         image: postgres:10
         env:
-          POSTGRES_DB: test_${{ matrix.backend }}
+          POSTGRES_DB: test_aiida
           POSTGRES_PASSWORD: ''
           POSTGRES_HOST_AUTH_METHOD: trust
         options: >-
@@ -52,7 +50,6 @@ jobs:
 
     - name: Run test suite
       env:
-        AIIDA_TEST_BACKEND: ${{ matrix.backend }}
         # show timings of tests
         PYTEST_ADDOPTS: "--durations=0"
       run: |


### PR DESCRIPTION
The backend string changed from `psql_dos` to `core.psql_dos`.
However, it is anyhow no longer needed to specify the backend explicitly, since we are only testing the default one.