### PR TITLE
👌 Parse test name to mock executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://github.com/aiidateam/aiida-testing/workflows/ci/badge.svg)](https://github.com/aiidateam/aiida-testing/actions)
 [![Docs status](https://readthedocs.org/projects/aiida-testing/badge)](http://aiida-testing.readthedocs.io/)
 [![PyPI version](https://badge.fury.io/py/aiida-testing.svg)](https://badge.fury.io/py/aiida-testing)
-[![GitHub license](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/aiidateam/aiida-testing/blob/master/LICENSE)
+[![GitHub license](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/aiidateam/aiida-testing/blob/main/LICENSE)
 
 # aiida-testing
 

--- a/aiida_testing/mock_code/_env_keys.py
+++ b/aiida_testing/mock_code/_env_keys.py
@@ -20,6 +20,7 @@ class MockVariables:  # pylint: disable=too-many-instance-attributes
 
     log_file: Path
     label: str
+    test_name: str
     data_dir: Path
     executable_path: str
     ignore_files: ty.Iterable[str]
@@ -36,6 +37,7 @@ class MockVariables:  # pylint: disable=too-many-instance-attributes
         return cls(
             log_file=Path(os.environ[_EnvKeys.LOG_FILE.value]),
             label=os.environ[_EnvKeys.LABEL.value],
+            test_name=os.environ[_EnvKeys.TEST_NAME.value],
             data_dir=Path(os.environ[_EnvKeys.DATA_DIR.value]),
             executable_path=os.environ[_EnvKeys.EXECUTABLE_PATH.value],
             ignore_files=os.environ[_EnvKeys.IGNORE_FILES.value].split(":"),
@@ -62,6 +64,7 @@ class MockVariables:  # pylint: disable=too-many-instance-attributes
         string = inspect.cleandoc(
             f"""
                 export {_EnvKeys.LOG_FILE.value}="{self.log_file}"
+                export {_EnvKeys.TEST_NAME.value}="{self.test_name.replace('"', "_")}"
                 export {_EnvKeys.LABEL.value}="{self.label}"
                 export {_EnvKeys.DATA_DIR.value}="{self.data_dir}"
                 export {_EnvKeys.EXECUTABLE_PATH.value}="{self.executable_path}"
@@ -87,6 +90,7 @@ class _EnvKeys(Enum):
     """
 
     LOG_FILE = "AIIDA_MOCK_LOG_FILE"
+    TEST_NAME = "AIIDA_MOCK_TEST_NAME"
     LABEL = "AIIDA_MOCK_LABEL"
     DATA_DIR = "AIIDA_MOCK_DATA_DIR"
     EXECUTABLE_PATH = "AIIDA_MOCK_EXECUTABLE_PATH"

--- a/aiida_testing/mock_code/_fixtures.py
+++ b/aiida_testing/mock_code/_fixtures.py
@@ -225,6 +225,7 @@ def mock_code_factory(
         variables = MockVariables(
             log_file=log_file.absolute(),
             label=label,
+            test_name=request.node.name,
             data_dir=data_dir_pl,
             executable_path=code_executable_path,
             ignore_files=ignore_files,


### PR DESCRIPTION
Can be useful for the hash hook (and if we want to add a hook to dump inputs with no cache-hit)