### PR TITLE
fix: add option to disable MPI

### DIFF
--- a/docs/source/user_guide/mock_code.rst
+++ b/docs/source/user_guide/mock_code.rst
@@ -81,7 +81,7 @@ The next time, it will recognise the inputs and directly use the outputs cached 
 Running continuous integration (CI) tests on your repository:
 
  - Don't forget to commit changes to your data directory to make the cache available on CI
- - Run tests on CI with ``pytest --mock-fail-on-missing`` so that it fails when the committed cache is incomplete
+ - Run tests on CI with ``pytest --mock-fail-on-missing`` to force a test failure when it fails when the committed cache is incomplete
 
 Since the ``.aiida-testing-config.yml`` file is usually specific to your machine, there is no need to commit it.
 As long as the test cache is complete, tests will run fine without it, and if other developers need to change test inputs, they can easily regenerate a template for it using ``pytest --testing-config-action=generate``.

--- a/docs/source/user_guide/mock_code.rst
+++ b/docs/source/user_guide/mock_code.rst
@@ -45,6 +45,7 @@ Second, we need to tell the mock executable where to find the *actual* ``diff`` 
       # code-label: absolute path
       diff: /usr/bin/diff
 
+
 .. note::
    Why yet another configuration file?
 
@@ -77,10 +78,13 @@ The next time, it will recognise the inputs and directly use the outputs cached 
     It does *not* rely on the hashing mechanism of AiiDA.
 
 
-Don't forget to add your data directory to your test data in order to make them available in CI and to other users of your plugin!
+Running continuous integration (CI) tests on your repository:
 
-Since the ``.aiida-testing-config.yml`` is usually specific to your machine, it usually better not to commit it.
-Tests will run fine without it, and if other developers need to change test inputs, they can easily regenerate a template for it using ``pytest --testing-config-action=generate``.
+ - Don't forget to commit changes to your data directory to make the cache available on CI
+ - Run tests on CI with ``pytest --mock-fail-on-missing`` so that it fails when the committed cache is incomplete
+
+Since the ``.aiida-testing-config.yml`` file is usually specific to your machine, there is no need to commit it.
+As long as the test cache is complete, tests will run fine without it, and if other developers need to change test inputs, they can easily regenerate a template for it using ``pytest --testing-config-action=generate``.
 
 For further documentation on the pytest commandline options added by mock code, see:
 
@@ -96,6 +100,9 @@ For further documentation on the pytest commandline options added by mock code, 
       --mock-regenerate-test-data
                             Regenerate test data.
 
+      --mock-fail-on-missing
+                            Fail if cached data is not found, rather than regenerating it.
+      --mock-disable-mpi    Run all calculations with `metadata.options.usempi=False`.
 
 Limitations
 -----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ pre_commit = [
     "pre-commit",
     "pylint~=2.12.2",
     "mypy==0.930",
+    "types-setuptools==65.7.0.3",
     "types-PyYAML",
 ]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ testing = [
     "pgtest~=1.3.1",
     "aiida-diff",
     "pytest-datadir",
+    "pytest-mock",
 ]
 pre_commit = [
     "pre-commit",

--- a/tests/mock_code/test_diff.py
+++ b/tests/mock_code/test_diff.py
@@ -8,9 +8,11 @@ import os
 import json
 import tempfile
 from pathlib import Path
+from pkg_resources import parse_version
 
 import pytest
 
+from aiida import __version__ as aiida_version
 from aiida.engine import run_get_node
 from aiida.plugins import CalculationFactory
 
@@ -211,11 +213,14 @@ def test_regenerate_test_data_executable(mock_code_factory, generate_diff_inputs
     assert (datadir / 'file1.txt').is_file()
 
 
-def test_with_mpi(mock_code_factory, generate_diff_inputs):  # pylint: disable=unused-argument
+@pytest.mark.skipif(
+    parse_version(aiida_version) < parse_version('2.1.0'), reason='requires AiiDA v2.1.0+'
+)
+def test_disable_mpi(mock_code_factory, generate_diff_inputs):  # pylint: disable=unused-argument
     """
     Check that disabling MPI is respected.
 
-    Let a CalcJob explicitly request MPI and check it is still run without MPI.
+    Let a CalcJob explicitly request `withmpi=True`, and check it is still run without MPI.
     """
     mock_code = mock_code_factory(
         label='diff',


### PR DESCRIPTION
CalcJob plugins can specify default values for whether codes should use MPI or not: using the `metadata.options.withmpi` variable.

aiida-testing can run calculations with a single MPI process if an MPI library is installed. However, the MPI library is then also required in order to fetch the results from the test database (because the mock executable will be run with `mpirun -np 1 ...`).

Here we add an option `--mock-disable-mpi` that allows users to disable the use of MPI (e.g. in order to run tests on CI in conjunction with `--mock-fail-on-missing`).