### PR TITLE
fix: backport typing

### DIFF
--- a/.aiida-testing-config.yml
+++ b/.aiida-testing-config.yml
@@ -10,3 +10,4 @@ archive_cache:
       #The test archives have version 0.8
       - environment_variables_double_quotes #This option was introduced in aiida-core 2.0
       - submit_script_filename #This option was introduced in aiida-core 1.2.1 (archive version 0.9)
+      - metadata_inputs # Added in aiida-core 2.3.0

--- a/aiida_testing/archive_cache/_fixtures.py
+++ b/aiida_testing/archive_cache/_fixtures.py
@@ -13,6 +13,11 @@ import typing as ty
 
 import pytest
 
+try:
+    from pytest import Parser
+except ImportError:
+    from _pytest.config.argparsing import Parser
+
 from aiida import plugins
 from aiida.common.links import LinkType
 from aiida.orm import Code, Dict, SinglefileData, List, FolderData, RemoteData, StructureData
@@ -29,7 +34,7 @@ __all__ = (
 )
 
 
-def pytest_addoption(parser: pytest.Parser) -> None:
+def pytest_addoption(parser: Parser) -> None:
     """Add pytest command line options."""
     parser.addoption(
         "--archive-cache-forbid-migration",


### PR DESCRIPTION
The `Parser` class was made available at `pytest.Parser` only for pytest 7.

See https://github.com/pytest-dev/pytest/commit/538b5c24999e9ebb4fab43faabc8bcc28737bcdf