### PR TITLE
Support new Python versions

### DIFF
--- a/.aiida-testing-config.yml
+++ b/.aiida-testing-config.yml
@@ -4,9 +4,10 @@ mock_code:
 archive_cache:
   ignore:
     calcjob_attributes:
-      #These attributes have to be ignored to be able to run the export cache tests
-      #while reusing the same test archive, migrating it to the needed version,
-      #since they are only present in newer versions
-      #The test archives have version 0.8
-      - environment_variables_double_quotes #This option was introduced in aiida-core 2.0
-      - submit_script_filename #This option was introduced in aiida-core 1.2.1 (archive version 0.9)
+      # These attributes have to be ignored to be able to run the export cache tests
+      # while reusing the same test archive, migrating it to the needed version,
+      # since they are only present in newer versions
+      # The test archives have version 0.8
+      - environment_variables_double_quotes # This option was introduced in aiida-core 2.0
+      - submit_script_filename # This option was introduced in aiida-core 1.2.1 (archive version 0.9)
+      - metadata_inputs # Added in aiida-core 2.3.0

--- a/.ci/install_aiida_github.sh
+++ b/.ci/install_aiida_github.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-git clone https://github.com/aiidateam/aiida_core ../aiida_core
-cd ../aiida_core
-git checkout $AIIDA_DEVELOP_GIT_HASH
-pip install -e .[docs,pre_commit,testing]
-cd ${TRAVIS_BUILD_DIR}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,11 +53,6 @@ jobs:
     - name: Install package
       run: uv pip install --system ${{ matrix.editable_install_option }} .[testing]
 
-    - name: Install python dependencies
-      run: |
-        pip install --upgrade pip
-        pip install ${{ matrix.editable_install_option }} .[testing]
-
     - name: Run test suite
       env:
         # show timings of tests
@@ -74,7 +69,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.11
+        python-version: 3.7
 
     - name: Set up uv
       uses: astral-sh/setup-uv@v3
@@ -95,7 +90,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.11
+        python-version: 3.10
 
     - name: Set up uv
       uses: astral-sh/setup-uv@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
         version: ${{ env.UV_VER }}
 
     - name: Install package
-      run: uv pip install --system -e .[dev]
+      run: uv pip install --system -e .[pre_commit]
 
     - name: Run pre-commit
       uses: pre-commit/action@v3.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
       fail-fast: false
 
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - name: Set up uv
       uses: astral-sh/setup-uv@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Set up uv
       uses: astral-sh/setup-uv@v3
       with:
-        version: ${UV_VER}
+        version: ${{ env.UV_VER }}
     - name: Install package
       run: uv pip install --system ${{ matrix.editable_install_option }} .[testing]
 
@@ -79,7 +79,7 @@ jobs:
     - name: Set up uv
       uses: astral-sh/setup-uv@v3
       with:
-        version: ${UV_VER}
+        version: ${{ env.UV_VER }}
     - name: Install package
       run: uv pip install --system -e .[docs]
 
@@ -100,7 +100,7 @@ jobs:
     - name: Set up uv
       uses: astral-sh/setup-uv@v3
       with:
-        version: ${UV_VER}
+        version: ${{ env.UV_VER }}
 
     - name: Install package
       run: uv pip install --system -e .[dev]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: ci
 
 on: [push, pull_request]
+env:
+    UV_VER: "0.5.2"
 
 jobs:
 
@@ -39,6 +41,13 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        version: ${UV_VER}
+    - name: Install package
+      run: uv pip install --system ${{ matrix.editable_install_option }} .[testing]
+
     - name: Install python dependencies
       run: |
         pip install --upgrade pip
@@ -61,10 +70,14 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
-    - name: Install python dependencies
-      run: |
-        pip install --upgrade pip
-        pip install -e .[docs]
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        version: ${UV_VER}
+    - name: Install package
+      run: uv pip install --system -e .[docs]
+
     - name: Build docs
       run: cd docs && make
 
@@ -73,14 +86,19 @@ jobs:
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v4
+
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
-    - name: Install python dependencies
-      run: |
-        pip install --upgrade pip
-        pip install -e .[pre_commit]
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        version: ${UV_VER}
+
+    - name: Install package
+      run: uv pip install --system -e .[dev]
+
     - name: Run pre-commit
-      run: |
-        pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
+      uses: pre-commit/action@v3.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,9 @@ jobs:
       with:
         version: ${{ env.UV_VER }}
     - name: Install package
-      run: uv pip install --system .[testing]
+      run: |
+        uv pip install --system -e .[testing]
+        reentry scan -r aiida || true
 
     - name: Run test suite
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,12 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
-        editable_install_option: ['-e', '']
+        editable_install_option: ['']
+        include:
+        # Test editable install
+        - python-version: '3.8'
+          editable_install_option: '-e'
+
       fail-fast: false
 
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7'
+        python-version: '3.8'
 
     - name: Set up uv
       uses: astral-sh/setup-uv@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: ci
+name: CI
 
 on: [push, pull_request]
 env:
@@ -12,13 +12,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
-        editable_install_option: ['']
-        include:
-        # Test editable install
-        - python-version: '3.8'
-          editable_install_option: '-e'
-
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
       fail-fast: false
 
     services:
@@ -52,7 +46,7 @@ jobs:
       with:
         version: ${{ env.UV_VER }}
     - name: Install package
-      run: uv pip install --system ${{ matrix.editable_install_option }} .[testing]
+      run: uv pip install --system .[testing]
 
     - name: Run test suite
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: ci
 on: [push, pull_request]
 env:
     UV_VER: "0.5.2"
+    FORCE_COLOR: 1
 
 jobs:
 
@@ -69,7 +70,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.7
+        python-version: '3.7'
 
     - name: Set up uv
       uses: astral-sh/setup-uv@v3
@@ -90,7 +91,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.10
+        python-version: '3.10'
 
     - name: Set up uv
       uses: astral-sh/setup-uv@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Set up uv
       uses: astral-sh/setup-uv@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,8 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: ['3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         editable_install_option: ['-e', '']
-        include:
-        #Test for aiida-core 1.X (since aiida-core 2.X does not support python 3.7)
-        - python-version: '3.7'
-          editable_install_option: '-e'
       fail-fast: false
 
     services:
@@ -37,9 +33,9 @@ jobs:
           - 5672:5672
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -47,7 +43,6 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install ${{ matrix.editable_install_option }} .[testing]
-        reentry scan -r aiida || true
 
     - name: Run test suite
       env:
@@ -61,16 +56,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.7
+        python-version: 3.11
     - name: Install python dependencies
       run: |
         pip install --upgrade pip
         pip install -e .[docs]
-        reentry scan -r aiida || true
     - name: Build docs
       run: cd docs && make
 
@@ -78,17 +72,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.11
     - name: Install python dependencies
       run: |
         pip install --upgrade pip
         pip install -e .[pre_commit]
-        reentry scan -r aiida || true
     - name: Run pre-commit
       run: |
-        pre-commit install
         pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.8'
+        python-version: '3.12'
 
     - name: Set up uv
       uses: astral-sh/setup-uv@v3

--- a/aiida_testing/_config.py
+++ b/aiida_testing/_config.py
@@ -48,7 +48,7 @@ class Config(collections.abc.MutableMapping):
         return self.schema(self._dict)
 
     @classmethod
-    def from_file(cls):
+    def from_file(cls) -> 'Config':
         """
         Parses the configuration file ``.aiida-testing-config.yml``.
 

--- a/aiida_testing/_config.py
+++ b/aiida_testing/_config.py
@@ -58,7 +58,7 @@ class Config(collections.abc.MutableMapping):
         cwd = pathlib.Path().cwd()
         config: ty.Dict[str, str]
         for dir_path in [cwd, *cwd.parents]:
-            config_file_path = (dir_path / CONFIG_FILE_NAME)
+            config_file_path = dir_path / CONFIG_FILE_NAME
             if config_file_path.exists():
                 with open(config_file_path, encoding='utf8') as config_file:
                     config = yaml.load(config_file, Loader=yaml.SafeLoader)

--- a/aiida_testing/archive_cache/_utils.py
+++ b/aiida_testing/archive_cache/_utils.py
@@ -115,9 +115,11 @@ try:
                 raise
 
 except ImportError:
-    from aiida.tools.importexport import export as create_archive  #type: ignore[import,no-redef]
-    from aiida.tools.importexport import import_data as import_archive  #type: ignore[no-redef]
-    import_archive = partial(import_archive, extras_mode_existing='ncu', extras_mode_new='import')
+    from aiida.tools.importexport import export as create_archive  # type: ignore[import-not-found,no-redef]
+    from aiida.tools.importexport import import_data as import_archive  # type: ignore[no-redef]
+    import_archive = partial(
+        import_archive, extras_mode_existing='ncu', extras_mode_new='import'
+    )  # type: ignore[call-arg]
 
     def import_with_migrate(
         archive_path: ty.Union[str, pathlib.Path],
@@ -133,7 +135,7 @@ except ImportError:
         from aiida.tools.importexport import EXPORT_VERSION, IncompatibleArchiveVersionError
         # these are only availbale after aiida >= 1.5.0, maybe rely on verdi import instead
         from aiida.tools.importexport import detect_archive_type
-        from aiida.tools.importexport.archive.migrators import get_migrator  #type: ignore[import]
+        from aiida.tools.importexport.archive.migrators import get_migrator  # type: ignore[import-not-found]
 
         try:
             import_archive(archive_path, *args, **kwargs)

--- a/aiida_testing/mock_code/_fixtures.py
+++ b/aiida_testing/mock_code/_fixtures.py
@@ -121,7 +121,7 @@ def mock_code_factory(
     aiida_localhost, testing_config, testing_config_action, mock_regenerate_test_data,
     mock_fail_on_missing, mock_disable_mpi, monkeypatch, request: pytest.FixtureRequest,
     tmp_path: pathlib.Path
-):  # pylint: disable=too-many-arguments,redefined-outer-name,unused-argument,too-many-statements
+):  # pylint: disable=all
     """
     Fixture to create a mock AiiDA Code.
 

--- a/aiida_testing/mock_code/_hasher.py
+++ b/aiida_testing/mock_code/_hasher.py
@@ -44,7 +44,7 @@ class InputHasher:
 
         return md5sum.hexdigest()
 
-    def modify_content(self, path: Path, content: bytes) -> ty.Optional[bytes]:  # pylint: disable=no-self-use,unused-argument
+    def modify_content(self, path: Path, content: bytes) -> ty.Optional[bytes]:  # pylint: disable=unused-argument
         """A sub-class hook to modify the contents of the file, before hashing.
 
         If None is returned, the file is ignored, when generating the hash.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Sphinx configuration for aiida-testing
 #
 # This file is execfile()d with the current directory set to its
@@ -37,7 +35,6 @@ else:
     with contextlib.suppress(ImportError):
         import sphinx_rtd_theme
         html_theme = 'sphinx_rtd_theme'
-        html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # -- General configuration ------------------------------------------------
 
@@ -56,7 +53,7 @@ extensions = [
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
-    'aiida': ('http://aiida-core.readthedocs.io/en/v1.6.8/', None),
+    'aiida': ('https://aiida.readthedocs.io/projects/aiida-core/en/stable/', None),
     'pytest': ('https://docs.pytest.org/en/latest/', None)
 }
 
@@ -66,24 +63,18 @@ templates_path = ['_templates']
 # The suffix of source filenames.
 source_suffix = '.rst'
 
-# The encoding of source files.
-#source_encoding = 'utf-8-sig'
-
 # The master toctree document.
-#~ master_doc = 'index'
 master_doc = 'index'
 
 # General information about the project.
-project = u'aiida-testing'
+project = 'aiida-testing'
 copyright_first_year = "2019"
 copyright_owners = "The AiiDA Team"
 
 current_year = str(time.localtime().tm_year)
-copyright_year_string = current_year if current_year == copyright_first_year else "{}-{}".format(
-    copyright_first_year, current_year
-)
+copyright_year_string = current_year if current_year == copyright_first_year else f"{copyright_first_year}-{current_year}"
 # pylint: disable=redefined-builtin
-copyright = u'{}, {}. All rights reserved'.format(copyright_year_string, copyright_owners)
+copyright = f'{copyright_year_string}, {copyright_owners}. All rights reserved'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -146,9 +137,7 @@ pygments_style = 'sphinx'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = {
-    'display_version': True,
-}
+# html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
 #~ html_theme_path = ["."]
@@ -221,9 +210,6 @@ html_use_opensearch = 'http://aiida-testing.readthedocs.io'
 #html_file_suffix = None
 
 # Language to be used for generating the HTML full-text search index.
-# Sphinx supports the following languages:
-#   'da', 'de', 'en', 'es', 'fi', 'fr', 'hu', 'it', 'ja'
-#   'nl', 'no', 'pt', 'ro', 'ru', 'sv', 'tr'
 html_search_language = 'en'
 
 # A dictionary with options for the search language support, empty by default.
@@ -291,11 +277,6 @@ def run_apidoc(_):
     source_dir = os.path.abspath(os.path.dirname(__file__))
     apidoc_dir = os.path.join(source_dir, 'apidoc')
     package_dir = os.path.join(source_dir, os.pardir, os.pardir, 'aiida_testing')
-
-    # In #1139, they suggest the route below, but this ended up
-    # calling sphinx-build, not sphinx-apidoc
-    #from sphinx.apidoc import main
-    #main([None, '-e', '-o', apidoc_dir, package_dir, '--force'])
 
     import subprocess
     cmd_path = 'sphinx-apidoc'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,12 +14,7 @@ import sys
 import time
 import contextlib
 
-from aiida.manage.configuration import load_documentation_profile
-
 import aiida_testing
-
-load_documentation_profile()
-
 # -- AiiDA-related setup --------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/docs/source/developer_guide/index.rst
+++ b/docs/source/developer_guide/index.rst
@@ -34,8 +34,7 @@ Enable enable automatic checks of code sanity and coding style::
     pre-commit install
 
 After this, the `yapf <https://github.com/google/yapf>`_ formatter,
-the `pylint <https://www.pylint.org/>`_ linter, the
-`prospector <https://pypi.org/project/prospector/>`_ code analyzer, and
+the `pylint <https://www.pylint.org/>`_ linter, and
 the `mypy <http://www.mypy-lang.org/>`_ static type checker will run
 at every commit.
 
@@ -71,17 +70,3 @@ Of course, you can also build the documentation locally::
     pip install -e .[docs]
     cd docs
     make
-
-PyPI release
-++++++++++++
-
-The process for creating a distribution and uploading it to PyPI is::
-
-    pip install twine
-    python setup.py sdist
-    twine upload dist/*
-
-This can only be done by people who are registered as ``aiida-testing``
-maintainers on PyPI. After this, you (and everyone else) should be able to::
-
-    pip install aiida-testing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ urls = {Homepage = "https://aiida-testing.readthedocs.io/"}
 requires-python = ">=3.8"
 # Note the dependency on setuptools due to pkg_resources
 dependencies = [
-    "aiida-core>=2.0.0,<3",
+    "aiida-core>=2.0.0,<2.6",
     "pytest>=7.0",
     "voluptuous~=0.12",
     "setuptools",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ keywords = [
 ]
 urls = {Homepage = "https://aiida-testing.readthedocs.io/"}
 requires-python = ">=3.7"
+# Note the dependency on setuptools due to pkg_resources
 dependencies = [
     "aiida-core>=2.0.0,<3.0.0",
     "pytest>=7.0",
@@ -61,14 +62,7 @@ pre_commit = [
     "types-PyYAML",
 ]
 dev = [
-    "sphinx",
-    "sphinx-rtd-theme",
-    "pgtest~=1.3.1",
-    "aiida-diff",
-    "pytest-datadir",
-    "pre-commit",
-    "pylint~=2.12.2",
-    "mypy==0.930",
+    'aiida-testing[testing,pre_commit,docs]',
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ urls = {Homepage = "https://aiida-testing.readthedocs.io/"}
 requires-python = ">=3.7"
 # Note the dependency on setuptools due to pkg_resources
 dependencies = [
-    "aiida-core>=1.0.0,<2.2",
+    "aiida-core>=1.0.0,<2.3",
     "pytest>=7.0",
     "voluptuous~=0.12",
     "setuptools",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ urls = {Homepage = "https://aiida-testing.readthedocs.io/"}
 requires-python = ">=3.7"
 # Note the dependency on setuptools due to pkg_resources
 dependencies = [
-    "aiida-core>=1.0.0,<2.6",
+    "aiida-core>=1.0.0,<2.1",
     "pytest>=7.0",
     "voluptuous~=0.12",
     "setuptools",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,11 @@ classifiers = [
     "Environment :: Plugins",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Physics",
     "Framework :: AiiDA",
     "Framework :: Pytest",
@@ -38,7 +39,7 @@ keywords = [
     "cache",
 ]
 urls = {Homepage = "https://aiida-testing.readthedocs.io/"}
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 # Note the dependency on setuptools due to pkg_resources
 dependencies = [
     "aiida-core>=2.0.0,<3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ testing = [
 pre_commit = [
     "pre-commit",
     "pylint~=2.12.2",
-    "mypy==0.930",
+    "mypy==1.13",
     "types-setuptools==65.7.0.3",
     "types-PyYAML",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ urls = {Homepage = "https://aiida-testing.readthedocs.io/"}
 requires-python = ">=3.7"
 # Note the dependency on setuptools due to pkg_resources
 dependencies = [
-    "aiida-core>=2.0.0,<3.0.0",
+    "aiida-core>=2.0.0,<2.4",
     "pytest>=7.0",
     "voluptuous~=0.12",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
     "Environment :: Plugins",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -38,10 +37,10 @@ keywords = [
     "cache",
 ]
 urls = {Homepage = "https://aiida-testing.readthedocs.io/"}
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
-    "aiida-core>=1.0.0,<3.0.0",
-    "pytest>=3.6",
+    "aiida-core>=2.0.0,<3.0.0",
+    "pytest>=7.0",
     "voluptuous~=0.12",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Environment :: Plugins",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -39,10 +40,10 @@ keywords = [
     "cache",
 ]
 urls = {Homepage = "https://aiida-testing.readthedocs.io/"}
-requires-python = ">=3.8"
+requires-python = ">=3.7"
 # Note the dependency on setuptools due to pkg_resources
 dependencies = [
-    "aiida-core>=2.0.0,<2.6",
+    "aiida-core>=1.0.0,<2.6",
     "pytest>=7.0",
     "voluptuous~=0.12",
     "setuptools",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ urls = {Homepage = "https://aiida-testing.readthedocs.io/"}
 requires-python = ">=3.7"
 # Note the dependency on setuptools due to pkg_resources
 dependencies = [
-    "aiida-core>=1.0.0,<2.1",
+    "aiida-core>=1.0.0,<2.2",
     "pytest>=7.0",
     "voluptuous~=0.12",
     "setuptools",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,9 +41,10 @@ urls = {Homepage = "https://aiida-testing.readthedocs.io/"}
 requires-python = ">=3.7"
 # Note the dependency on setuptools due to pkg_resources
 dependencies = [
-    "aiida-core>=2.0.0,<2.4",
+    "aiida-core>=2.0.0,<3",
     "pytest>=7.0",
     "voluptuous~=0.12",
+    "setuptools",
 ]
 
 [project.optional-dependencies]
@@ -56,7 +57,7 @@ testing = [
 ]
 pre_commit = [
     "pre-commit",
-    "pylint~=2.12.2",
+    "pylint~=3.3.1",
     "mypy==1.13",
     "types-setuptools==65.7.0.3",
     "types-PyYAML",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Environment :: Plugins",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -37,7 +38,7 @@ keywords = [
     "cache",
 ]
 urls = {Homepage = "https://aiida-testing.readthedocs.io/"}
-requires-python = ">=3.8"
+requires-python = ">=3.7"
 dependencies = [
     "aiida-core>=2.0.0,<3.0.0",
     "pytest>=7.0",

--- a/tests/archive_cache/test_archive_cache.py
+++ b/tests/archive_cache/test_archive_cache.py
@@ -153,7 +153,7 @@ def test_mock_hash_codes(mock_code_factory, clear_database, liberal_hash):
 def test_enable_archive_cache(
     archive_path, aiida_local_code_factory, generate_diff_inputs, enable_archive_cache,
     clear_database, check_diff_workchain
-):
+):  # pylint: disable=too-many-positional-arguments
     """
     Basic test of the enable_archive_cache fixture
     """
@@ -171,7 +171,7 @@ def test_enable_archive_cache(
 def test_enable_archive_cache_non_existent(
     aiida_local_code_factory, generate_diff_inputs, enable_archive_cache, clear_database,
     tmp_path_factory, check_diff_workchain
-):
+):  # pylint: disable=too-many-positional-arguments
     """
     Test of the enable_archive_cache fixture that creation of the archive
     and overwriting of the archive works correctly


### PR DESCRIPTION
Test with new Python versions up to 3.12 (aiida-core doesn't support 3.13 yet).

EDIT: See comments below, in this PR I restricted the aiida-core versions to below or equal to 2.2, which is the last version that doesn't break any tests. Will open a follow-up PR.