### PR TITLE
Link to original RTD url

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,26 +58,6 @@ jobs:
         aiida-mock-code || true
         cd tests; pytest
 
-  docs:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
-
-    - name: Set up uv
-      uses: astral-sh/setup-uv@v3
-      with:
-        version: ${{ env.UV_VER }}
-    - name: Install package
-      run: uv pip install --system -e .[docs]
-
-    - name: Build docs
-      run: cd docs && make
-
   pre-commit:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+    push:
+        branches:
+            - main
+    pull_request:
 env:
     UV_VER: "0.5.2"
     FORCE_COLOR: 1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://github.com/aiidateam/aiida-test-cache/actions/workflows/ci.yml/badge.svg)](https://github.com/aiidateam/aiida-test-cache/actions)
-[![Docs status](https://readthedocs.org/projects/aiida-test-cache/badge)](https://aiida-test-cache.readthedocs.io/)
+[![Docs status](https://readthedocs.org/projects/aiida-testing/badge)](https://aiida-testing.readthedocs.io/)
 [![PyPI version](https://badge.fury.io/py/aiida-test-cache.svg)](https://badge.fury.io/py/aiida-test-cache)
 [![GitHub license](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/aiidateam/aiida-test-cache/blob/main/LICENSE)
 
@@ -9,4 +9,4 @@ A pytest plugin to simplify testing of AiiDA plugins. This package implements tw
 - `mock_code`: Implements a caching layer at the level of the executable called by an AiiDA calculation. This tests the input generation and output parsing, which is useful when testing calculation and parser plugins.
 - `archive_cache`: Implements an automatic archive creation and loading, to enable AiiDA - level caching in tests. This circumvents the input generation / output parsing, making it suitable for testing higher-level workflows. 
 
-For more information, see the [documentation](http://aiida-test-cache.readthedocs.io/).
+For more information, see the [documentation](https://aiida-testing.readthedocs.io/).

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -199,7 +199,7 @@ html_show_sourcelink = False
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-html_use_opensearch = 'http://aiida-test-cache.readthedocs.io'
+html_use_opensearch = 'https://aiida-testing.readthedocs.io'
 
 # This is the file name suffix for HTML files (e.g. ".xhtml").
 #html_file_suffix = None

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,10 +2,10 @@
     :width: 250px
     :align: center
 
-The aiida-test-cache pytest plugin
+aiida-test-cache pytest plugin
 ==================================
 
-A pytest plugin to simplify testing of `AiiDA`_ plugins. It implements
+A pytest plugin to simplify testing of `AiiDA`_ workflows. It implements
 fixtures to cache the execution of codes:
 
 * :mod:`.mock_code`: Caches at the level of the code executable. Use this for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ keywords = [
     "mock",
     "cache",
 ]
-urls = {Homepage = "https://aiida-test-cache.readthedocs.io/"}
+urls = {Homepage = "https://aiida-testing.readthedocs.io/"}
 requires-python = ">=3.7"
 # Note the dependency on setuptools due to pkg_resources
 dependencies = [


### PR DESCRIPTION
Unfortunately, ReadTheDocs does not support creating a new URL when a project is renamed. Essentially we'd need to create a new project on RTD from scratch.
To save us from this churn, we simply link to the original URL. 

Not great, not terrible.