### PR TITLE
CI:  Publish workflow (PyPI)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,9 @@
 # WARNING: This file should not be renamed!
 # It's name is tied to Trusted Publishing on PyPI.
+#
+# Deploy to PyPI when a release tag vX.Y.Z is created.
+# Will only be published to PyPI if the git tag matches the released version.
+# Additionally, creating a "test-release" label on a PR will trigger a publish to TestPyPI.
 name: Publish
 
 on:
@@ -7,13 +11,33 @@ on:
     tags:
       - "v*"
   pull_request:
-    # Trigger TestPyPI publish when the `test-release` label is added to a PR
     types: [labeled]
 
 env:
   FORCE_COLOR: 1
 
 jobs:
+
+  check-release-tag:
+    name: Check tag version
+    if: >-
+      github.repository == 'aiidateam/aiida-test-cache' &&
+      github.event_name == 'push' &&
+      github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Check version tag
+        run: |
+          ver=$(python -c "from tomllib import load;p=load(open('pyproject.toml','rb'));print(p['project']['version'])")
+          errormsg="tag '${{ github.ref_name }}' does not match version '$ver' from pyproject.toml"
+          if [ "v${ver}" != "${{ github.ref_name }}" ]; then echo "$errormsg"; exit 1; fi
+
+
   dist:
     name: Distribution build
     runs-on: ubuntu-latest
@@ -24,6 +48,7 @@ jobs:
           fetch-depth: 0
 
       - uses: hynek/build-and-inspect-python-package@v2
+
 
   test-publish:
     needs: [dist]
@@ -62,9 +87,10 @@ jobs:
         with:
           labels: test-release
 
+
   pypi-publish:
     name: Publish release to PyPI
-    needs: [dist]
+    needs: [dist, check-version]
     if: >-
       github.repository == 'aiidateam/aiida-test-cache' &&
       github.event_name == 'push' &&
@@ -72,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
        name: pypi
-       url: https://pypi.org/p/promdens/
+       url: https://pypi.org/p/aiida-test-cache/
     permissions:
       id-token: write
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,10 +91,9 @@ jobs:
     name: Publish release to PyPI
     needs: [dist, check-release-tag]
     if: >-
-      false &&
       github.repository == 'aiidateam/aiida-test-cache' &&
       github.event_name == 'push' &&
-      github.ref_type == 'invalid'
+      github.ref_type == 'tag'
     runs-on: ubuntu-latest
     environment:
        name: pypi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,85 @@
+# WARNING: This file should not be renamed!
+# It's name is tied to Trusted Publishing on PyPI.
+name: Publish
+
+on:
+  push:
+    tags:
+      - "v*"
+  pull_request:
+    # Trigger TestPyPI publish when the `test-release` label is added to a PR
+    types: [labeled]
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  dist:
+    name: Distribution build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: hynek/build-and-inspect-python-package@v2
+
+  test-publish:
+    needs: [dist]
+    name: Publish to TestPyPI
+    if: >-
+      github.repository == 'aiidateam/aiida-test-cache' &&
+      github.event_name == 'pull_request' &&
+      github.event.action == 'labeled' &&
+      github.event.label.name == 'test-release'
+    environment:
+       name: testpypi
+       url: https://test.pypi.org/p/aiida-test-cache/
+    permissions:
+      id-token: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+      # Remove the PR label which triggered this release,
+      # but only if the release failed. Presumably, in this case we might want
+      # to fix whatever caused the failure and re-trigger the test release.
+      # If the release succeeded, re-triggering the release would fail anyway,
+      # unless the version would be bumped again.
+      - name: Remove test-release label
+        if: failure()
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: test-release
+
+  pypi-publish:
+    name: Publish release to PyPI
+    needs: [dist]
+    if: >-
+      github.repository == 'aiidateam/aiida-test-cache' &&
+      github.event_name == 'push' &&
+      github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    environment:
+       name: pypi
+       url: https://pypi.org/p/promdens/
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,10 @@ jobs:
 
   check-release-tag:
     name: Check tag version
+    if: >-
+      github.repository == 'aiidateam/aiida-test-cache' &&
+      github.event_name == 'push' &&
+      github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,10 +20,6 @@ jobs:
 
   check-release-tag:
     name: Check tag version
-    if: >-
-      github.repository == 'aiidateam/aiida-test-cache' &&
-      github.event_name == 'push' &&
-      github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,9 +91,10 @@ jobs:
     name: Publish release to PyPI
     needs: [dist, check-release-tag]
     if: >-
+      false &&
       github.repository == 'aiidateam/aiida-test-cache' &&
       github.event_name == 'push' &&
-      github.ref_type == 'tag'
+      github.ref_type == 'invalid'
     runs-on: ubuntu-latest
     environment:
        name: pypi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Check version tag
         run: |
           ver=$(python -c "from tomllib import load;p=load(open('pyproject.toml','rb'));print(p['project']['version'])")
-          errormsg="tag version '${{ github.ref_name }}' != v'$ver' specified in pyproject.toml"
+          errormsg="tag version '${{ github.ref_name }}' != 'v$ver' specified in pyproject.toml"
           if [ "v${ver}" != "${{ github.ref_name }}" ]; then echo "$errormsg"; exit 1; fi
 
   dist:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,9 +34,8 @@ jobs:
       - name: Check version tag
         run: |
           ver=$(python -c "from tomllib import load;p=load(open('pyproject.toml','rb'));print(p['project']['version'])")
-          errormsg="tag '${{ github.ref_name }}' does not match version '$ver' from pyproject.toml"
+          errormsg="tag version '${{ github.ref_name }}' != v'$ver' specified in pyproject.toml"
           if [ "v${ver}" != "${{ github.ref_name }}" ]; then echo "$errormsg"; exit 1; fi
-
 
   dist:
     name: Distribution build
@@ -90,7 +89,7 @@ jobs:
 
   pypi-publish:
     name: Publish release to PyPI
-    needs: [dist, check-version]
+    needs: [dist, check-release-tag]
     if: >-
       github.repository == 'aiidateam/aiida-test-cache' &&
       github.event_name == 'push' &&

--- a/aiida_test_cache/__init__.py
+++ b/aiida_test_cache/__init__.py
@@ -1,3 +1,1 @@
 """A pytest plugin for testing AiiDA plugins."""
-
-__version__ = '0.1.0.dev1'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,11 +10,10 @@
 # serve to show the default.
 
 import contextlib
+import importlib.metadata
 import os
 import sys
 import time
-
-import aiida_test_cache
 
 # -- AiiDA-related setup --------------------------------------------------
 
@@ -76,7 +75,7 @@ copyright = f'{copyright_year_string}, {copyright_owners}. All rights reserved' 
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-release = aiida_test_cache.__version__
+release = importlib.metadata.version('aiida_test_cache')
 # The short X.Y version.
 version = '.'.join(release.split('.')[:2])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "aiida_test_cache"
 
 [project]
 name = "aiida-test-cache"
-version = "0.0.1a0"
+version = "0.0.1a1"
 description = "A pytest plugin to simplify testing of AiiDA workflows"
 authors = [
     {name = "Dominik Gresch"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,8 @@ name = "aiida_test_cache"
 
 [project]
 name = "aiida-test-cache"
+version = "0.0.1a0"
 description = "A pytest plugin to simplify testing of AiiDA workflows"
-dynamic = ["version"]
 authors = [
     {name = "Dominik Gresch"},
     {name = "Leopold Talirz"},


### PR DESCRIPTION
This adds a GHA workflow for publishing to PyPI. 

This uses the relatively new [Trusted Publisher](https://docs.pypi.org/trusted-publishers/) authentication mechanism, which does not require storing a secret token in repository settings (we should consider migrating aiida-core to this as well imo).

The workflow itself is triggered when a tag is created (Typically by creating a release on GitHub UI). Additionally, one can test the release by publishing to TestPyPI by adding a `test-release` label to a PR.

I have used this workflow in another (non-AiiDA) repository and it's been working well.

Closes #72 

