### PR TITLE
Support aiida 2.5

### DIFF
--- a/aiida_test_cache/mock_code/_hasher.py
+++ b/aiida_test_cache/mock_code/_hasher.py
@@ -34,6 +34,10 @@ class InputHasher:
                 file_content_bytes = file_obj.read()
             if path.name == self.SUBMIT_FILE:
                 file_content_bytes = self._strip_submit_content(file_content_bytes)
+                # TODO: This is a temporary ugly hack for backward compatibility with aiida-core<2.3
+                # REVERT THIS after 0.0.1 release!
+                if not file_content_bytes.endswith(b" "):
+                    file_content_bytes += b" "
             file_content_bytes = self.modify_content(path, file_content_bytes)
             if file_content_bytes is not None:
                 md5sum.update(path.name.encode())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ urls = {Homepage = "https://aiida-testing.readthedocs.io/"}
 requires-python = ">=3.7"
 # Note the dependency on setuptools due to pkg_resources
 dependencies = [
-    "aiida-core>=1.0.0,<2.3",
+    "aiida-core>=1.0.0,<2.6",
     "pytest>=7.0",
     "voluptuous~=0.12",
     "setuptools",


### PR DESCRIPTION
We saw a failing mock_code test since aiida 2.3.0 (see #75)
This was caused by just a whitespace change in the AiiDA
submission script (controlled by the direct Scheduler plugin).

Concretely, there was an extra space at the end of the last
line of the script (the executable line) before 2.3.
As a short term solution to preserve the existing hashes,
we append a space if the script doesn't end with one.

This change is purely for backwards compatibility and should be
reverted right after 0.0.1 release.

As a longer term solution we should make this less brittle, perhaps by removing all white space in the submission script. But even that still makes us dependent on the core.direct scheduler implementation. I'll open a separate issue to track that.

Closes #75 