### PR TITLE
Release v0.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "aiida_test_cache"
 
 [project]
 name = "aiida-test-cache"
-version = "0.0.1a1"
+version = "0.0.1"
 description = "A pytest plugin to simplify testing of AiiDA workflows"
 authors = [
     {name = "Dominik Gresch"},


### PR DESCRIPTION
Turns out that supporting aiida-core v2.6 is more work (see #85) so I am going to publish a backward compatible release v0.0.1 that still supports aiida v1(!) up and including 2.5, but not v2.6. 
It also still supports Python 3.7.

For v0.1 I am going to bump minimum Python and aiida-core versions.