### PR TITLE
Drop AiiDA v1 support, drop Python 3.7/3.8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
+        aiida-version: ['2.5']
+        include:
+          - python-version: '3.9'
+            aiida-version: '2.0'
       fail-fast: false
 
     services:
@@ -50,7 +54,7 @@ jobs:
       with:
         version: ${{ env.UV_VER }}
     - name: Install package
-      run: uv pip install --system -e .[tests]
+      run: uv pip install --system -e .[tests] aiida-core==${{ matrix.aiida-version }}
 
     - name: Run test suite
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
             - main
     pull_request:
 env:
-    UV_VER: "0.5.2"
+    UV_VER: "0.5.6"
     FORCE_COLOR: 1
 
 jobs:
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
       fail-fast: false
 
     services:
@@ -46,13 +46,11 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v4
       with:
         version: ${{ env.UV_VER }}
     - name: Install package
-      run: |
-        uv pip install --system -e .[tests]
-        reentry scan -r aiida || true
+      run: uv pip install --system -e .[tests]
 
     - name: Run test suite
       env:
@@ -60,7 +58,7 @@ jobs:
         PYTEST_ADDOPTS: "--durations=0"
       run: |
         aiida-mock-code || true
-        pytest -s --cov=aiida_test_cache tests/
+        pytest --cov=aiida_test_cache tests/
 
     - name: Upload coverage report
       uses: codecov/codecov-action@v5
@@ -82,7 +80,7 @@ jobs:
         python-version: '3.12'
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v4
       with:
         version: ${{ env.UV_VER }}
 
@@ -90,4 +88,4 @@ jobs:
       run: uv pip install --system -e .[pre_commit]
 
     - name: Run pre-commit
-      uses: pre-commit/action@v3.0.1
+      uses: pre-commit/action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,4 +88,4 @@ jobs:
       run: uv pip install --system -e .[pre_commit]
 
     - name: Run pre-commit
-      uses: pre-commit/action@v3
+      uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     additional_dependencies: [toml]
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.7.4
+  rev: v0.8.1
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix, --show-fixes]

--- a/aiida_test_cache/_config.py
+++ b/aiida_test_cache/_config.py
@@ -4,7 +4,6 @@ Helpers for managing the ``.aiida-test-cache-config.yml`` configuration file.
 
 import collections
 import pathlib
-import typing as ty
 from enum import Enum
 
 import yaml
@@ -55,7 +54,7 @@ class Config(collections.abc.MutableMapping):
         directories.
         """
         cwd = pathlib.Path().cwd()
-        config: ty.Dict[str, str]
+        config: dict[str, str]
         for dir_path in [cwd, *cwd.parents]:
             config_file_path = dir_path / CONFIG_FILE_NAME
             if config_file_path.exists():

--- a/aiida_test_cache/archive_cache/__init__.py
+++ b/aiida_test_cache/archive_cache/__init__.py
@@ -7,6 +7,6 @@ to enable AiiDA - level caching.
 from ._fixtures import *
 
 __all__ = (
-    "pytest_addoption", "absolute_archive_path", "enable_archive_cache", "liberal_hash",
-    "archive_cache_forbid_migration", "archive_cache_overwrite"
+    "absolute_archive_path", "archive_cache_forbid_migration", "archive_cache_overwrite",
+    "enable_archive_cache", "liberal_hash", "pytest_addoption"
 )

--- a/aiida_test_cache/archive_cache/_fixtures.py
+++ b/aiida_test_cache/archive_cache/_fixtures.py
@@ -33,8 +33,8 @@ from ._utils import (
 )
 
 __all__ = (
-    "pytest_addoption", "absolute_archive_path", "enable_archive_cache", "liberal_hash",
-    "archive_cache_forbid_migration", "archive_cache_overwrite"
+    "absolute_archive_path", "archive_cache_forbid_migration", "archive_cache_overwrite",
+    "enable_archive_cache", "liberal_hash", "pytest_addoption"
 )
 
 
@@ -172,8 +172,7 @@ def enable_archive_cache(
     @contextmanager
     def _enable_archive_cache(
         archive_path: ty.Union[str, pathlib.Path],
-        calculation_class: ty.Union[ty.Type[CalcJobNode], ty.Sequence[ty.Type[CalcJobNode]],
-                                    None] = None,
+        calculation_class: ty.Union[type[CalcJobNode], ty.Sequence[type[CalcJobNode]], None] = None,
         overwrite: bool = False
     ) -> ty.Generator[None, None, None]:
         """
@@ -210,7 +209,7 @@ def enable_archive_cache(
             # create export of all calculation_classes
             # Another solution out of this is to check the time before and
             # after the yield and export ONLY the jobcalc classes created within this time frame
-            queryclass: ty.Union[ty.Type[CalcJobNode], ty.Sequence[ty.Type[CalcJobNode]]]
+            queryclass: ty.Union[type[CalcJobNode], ty.Sequence[type[CalcJobNode]]]
             if calculation_class is None:
                 queryclass = CalcJobNode
             else:

--- a/aiida_test_cache/archive_cache/_utils.py
+++ b/aiida_test_cache/archive_cache/_utils.py
@@ -11,7 +11,7 @@ import pytest
 from aiida.cmdline.utils.echo import echo_warning
 from aiida.orm import Node, ProcessNode, QueryBuilder
 
-__all__ = ('rehash_processes', 'monkeypatch_hash_objects')
+__all__ = ('monkeypatch_hash_objects', 'rehash_processes')
 
 
 def rehash_processes() -> None:
@@ -26,7 +26,7 @@ def rehash_processes() -> None:
 
 
 def monkeypatch_hash_objects(
-    monkeypatch: pytest.MonkeyPatch, node_class: ty.Type[Node], hash_objects_func: ty.Callable
+    monkeypatch: pytest.MonkeyPatch, node_class: type[Node], hash_objects_func: ty.Callable
 ) -> None:
     """
     Monkeypatch the _get_objects_to_hash method in aiida-core for the given node class
@@ -168,7 +168,7 @@ def load_node_archive(archive_path: str, forbid_migration: bool = False) -> None
 
 
 def create_node_archive(
-    nodes: ty.Union[Node, ty.List[Node]], archive_path: str, overwrite: bool = True
+    nodes: ty.Union[Node, list[Node]], archive_path: str, overwrite: bool = True
 ) -> None:
     """
     Function to export an AiiDA graph from a given node.

--- a/aiida_test_cache/mock_code/__init__.py
+++ b/aiida_test_cache/mock_code/__init__.py
@@ -9,11 +9,11 @@ from ._hasher import InputHasher  # noqa: F401
 
 # Note: This is necessary for the sphinx doc - otherwise it does not find aiida_test_cache.mock_code.mock_code_factory
 __all__ = (
-    "pytest_addoption",
-    "testing_config_action",
-    "mock_regenerate_test_data",
-    "testing_config",
     "mock_code_factory",
+    "mock_regenerate_test_data",
+    "pytest_addoption",
+    "testing_config",
+    "testing_config_action",
 )
 
 # ensure aiida's pytest plugin is loaded, which we rely on

--- a/aiida_test_cache/mock_code/_cli.py
+++ b/aiida_test_cache/mock_code/_cli.py
@@ -98,7 +98,7 @@ def copy_files(
         destination.
     :param ignore_paths: A list of paths (UNIX shell style patterns allowed) which are not copied to the destination.
     """
-    exclude_paths: ty.Set = {filepath for path in ignore_paths for filepath in src_dir.glob(path)}
+    exclude_paths: set = {filepath for path in ignore_paths for filepath in src_dir.glob(path)}
     exclude_files = {path.relative_to(src_dir) for path in exclude_paths if path.is_file()}
     exclude_dirs = {path.relative_to(src_dir) for path in exclude_paths if path.is_dir()}
 

--- a/aiida_test_cache/mock_code/_env_keys.py
+++ b/aiida_test_cache/mock_code/_env_keys.py
@@ -26,7 +26,7 @@ class MockVariables:
     ignore_paths: ty.Iterable[str]
     regenerate_data: bool
     fail_on_missing: bool
-    _hasher: ty.Union[str, ty.Type[InputHasher]]
+    _hasher: ty.Union[str, type[InputHasher]]
 
     @classmethod
     def from_env(cls) -> "MockVariables":
@@ -46,7 +46,7 @@ class MockVariables:
             _hasher=os.environ.get(_EnvKeys.HASHER.value, InputHasher),
         )
 
-    def get_hasher(self) -> ty.Type[InputHasher]:
+    def get_hasher(self) -> type[InputHasher]:
         """
         Return the hasher class.
         """

--- a/aiida_test_cache/mock_code/_fixtures.py
+++ b/aiida_test_cache/mock_code/_fixtures.py
@@ -21,13 +21,13 @@ from ._env_keys import MockVariables
 from ._hasher import InputHasher
 
 __all__ = (
-    "pytest_addoption",
-    "testing_config_action",
-    "mock_regenerate_test_data",
-    "mock_fail_on_missing",
-    "mock_disable_mpi",
-    "testing_config",
     "mock_code_factory",
+    "mock_disable_mpi",
+    "mock_fail_on_missing",
+    "mock_regenerate_test_data",
+    "pytest_addoption",
+    "testing_config",
+    "testing_config_action",
 )
 
 
@@ -137,7 +137,7 @@ def mock_code_factory(
         ignore_files: ty.Iterable[str] = ('_aiidasubmit.sh', ),
         ignore_paths: ty.Iterable[str] = ('_aiidasubmit.sh', ),
         executable_name: str = '',
-        hasher: ty.Type[InputHasher] = InputHasher,
+        hasher: type[InputHasher] = InputHasher,
         _config: Config = testing_config,
         _config_action: str = testing_config_action,
         _regenerate_test_data: bool = mock_regenerate_test_data,

--- a/aiida_test_cache/mock_code/_hasher.py
+++ b/aiida_test_cache/mock_code/_hasher.py
@@ -70,7 +70,7 @@ class InputHasher:
         return '\n'.join(lines).encode()
 
 
-def load_hasher(path: ty.Union[str, Path], class_name: str) -> ty.Type[InputHasher]:
+def load_hasher(path: ty.Union[str, Path], class_name: str) -> type[InputHasher]:
     """
     Load the InputHasher class from the given path.
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,6 @@ classifiers = [
     "Environment :: Plugins",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -41,10 +39,10 @@ keywords = [
     "cache",
 ]
 urls = {Homepage = "https://aiida-testing.readthedocs.io/"}
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 # Note the dependency on setuptools due to pkg_resources
 dependencies = [
-    "aiida-core>=1.0.0,<2.6",
+    "aiida-core>=2.0,<2.6",
     "pytest>=7.0",
     "voluptuous~=0.12",
     "setuptools",
@@ -54,7 +52,7 @@ dependencies = [
 docs = ["sphinx", "sphinx-rtd-theme"]
 tests = [
     "pgtest~=1.3.1",
-    "aiida-diff",
+    "aiida-diff~=2.0.0",
     "pytest-datadir",
     "pytest-mock",
     "pytest-cov>=4.0",
@@ -136,16 +134,16 @@ ignore_missing_imports = true
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py38
+envlist = py39
 
 [testenv]
 usedevelop = true
 
-[testenv:py{37,38,39,310,311}]
+[testenv:py{39,310,311,312}]
 extras = tests
 commands = pytest {posargs}
 
-[testenv:pre-commit-py{38,39,310,311}]
+[testenv:pre-commit-py{39,310,311,312}]
 extras = 
     pre_commit
 commands = pre-commit {posargs:run --all}


### PR DESCRIPTION
In this PR I just drop the support in `pyproject.toml`. I'll delete the actual code that is needed for AiiDA v1 in a separate PR (such code is identifiable by the code coverage changes here).

Also I added a CI jobs that tests the minimum supported aiida-core version
(which is 2.0 at the moment).

Upon bumping the minimum Python version, ruff has some suggestions as well. 