### PR TITLE
Bump minimum AiiDA version for 2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,10 @@ jobs:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
         aiida-version: ['2.5']
+        # Include a job with minimum supported aiida-version
         include:
           - python-version: '3.9'
-            aiida-version: '2.0'
+            aiida-version: '2.1'
       fail-fast: false
 
     services:

--- a/aiida_test_cache/mock_code/_fixtures.py
+++ b/aiida_test_cache/mock_code/_fixtures.py
@@ -11,9 +11,7 @@ import uuid
 
 import click
 import pytest
-from aiida import __version__ as aiida_version
 from aiida.orm import Code
-from pkg_resources import parse_version
 
 from .._config import CONFIG_FILE_NAME, Config, ConfigActions
 from ._env_keys import MockVariables
@@ -251,19 +249,10 @@ def mock_code_factory(
         # Monkeypatch MPI behavior of code class, if requested either directly via `--mock-disable-mpi` or
         # indirectly via `--mock-fail-on-missing` (no need to use MPI in this case)
         if _disable_mpi or _fail_on_missing:
-            is_mpi_disable_supported = parse_version(aiida_version) >= parse_version('2.1.0')
-
-            if not is_mpi_disable_supported:
-                if _disable_mpi:
-                    raise ValueError(
-                        "Upgrade to AiiDA >= 2.1.0 in order to use `--mock-disable-mpi`"
-                    )
-                # if only _fail_on_missing, we silently do not disable MPI
-            else:
-                monkeypatch.setattr(
-                    code.__class__, 'get_prepend_cmdline_params',
-                    _forget_mpi_decorator(code.__class__.get_prepend_cmdline_params)
-                )
+            monkeypatch.setattr(
+                code.__class__, 'get_prepend_cmdline_params',
+                _forget_mpi_decorator(code.__class__.get_prepend_cmdline_params)
+            )
 
         return code
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,12 +40,10 @@ keywords = [
 ]
 urls = {Homepage = "https://aiida-testing.readthedocs.io/"}
 requires-python = ">=3.9"
-# Note the dependency on setuptools due to pkg_resources
 dependencies = [
-    "aiida-core>=2.0,<2.6",
+    "aiida-core>=2.1,<2.6",
     "pytest>=7.0",
     "voluptuous~=0.12",
-    "setuptools",
 ]
 
 [project.optional-dependencies]
@@ -60,7 +58,6 @@ tests = [
 pre_commit = [
     "pre-commit",
     "mypy==1.13",
-    "types-setuptools==65.7.0.3",
     "types-PyYAML",
 ]
 dev = [

--- a/tests/mock_code/test_diff.py
+++ b/tests/mock_code/test_diff.py
@@ -9,10 +9,8 @@ import tempfile
 from pathlib import Path
 
 import pytest
-from aiida import __version__ as aiida_version
 from aiida.engine import run_get_node
 from aiida.plugins import CalculationFactory
-from pkg_resources import parse_version
 
 CALC_ENTRY_POINT = 'diff'
 
@@ -211,9 +209,6 @@ def test_regenerate_test_data_executable(mock_code_factory, generate_diff_inputs
     assert (datadir / 'file1.txt').is_file()
 
 
-@pytest.mark.skipif(
-    parse_version(aiida_version) < parse_version('2.1.0'), reason='requires AiiDA v2.1.0+'
-)
 def test_disable_mpi(mock_code_factory, generate_diff_inputs):
     """
     Check that disabling MPI is respected.


### PR DESCRIPTION
aiida-core v2.1.0 was released in 2022-11-07 so it should be fine to require it.

This let's us delete some special-case code and drop the dependency on setuptools.