### PR TITLE
Resolve aiida-core v3 deprecations

### DIFF
--- a/aiida_test_cache/archive_cache/_fixtures.py
+++ b/aiida_test_cache/archive_cache/_fixtures.py
@@ -249,7 +249,7 @@ def liberal_hash(monkeypatch: pytest.MonkeyPatch, testing_config: Config) -> Non
         """
         self = get_node_from_hash_objects_caller(self)
         # computer names are changed by aiida-core if imported and do not have same uuid.
-        return [self.get_attribute(key='input_plugin')]
+        return [self.base.attributes.get(key='input_plugin')]
 
     def mock_objects_to_hash_calcjob(self):
         """
@@ -265,14 +265,14 @@ def liberal_hash(monkeypatch: pytest.MonkeyPatch, testing_config: Config) -> Non
 
         objects = [{
             key: val
-            for key, val in self.attributes_items()
+            for key, val in self.base.attributes.items()
             if key not in self._hash_ignored_attributes and key not in self._updatable_attributes
         },
                    {
-                       entry.link_label: entry.node.get_hash()
-                       for entry in
-                       self.get_incoming(link_type=(LinkType.INPUT_CALC, LinkType.INPUT_WORK))
-                       if entry.link_label not in hash_ignored_inputs
+                       entry.link_label: entry.node.base.caching.get_hash()
+                       for entry in self.base.links.get_incoming(
+                           link_type=(LinkType.INPUT_CALC, LinkType.INPUT_WORK)
+                       ) if entry.link_label not in hash_ignored_inputs
                    }]
         return objects
 
@@ -289,8 +289,8 @@ def liberal_hash(monkeypatch: pytest.MonkeyPatch, testing_config: Config) -> Non
         objects = [
             {
                 key: val
-                for key, val in self.attributes_items() if key not in self._hash_ignored_attributes
-                and key not in self._updatable_attributes
+                for key, val in self.base.attributes.items() if
+                key not in self._hash_ignored_attributes and key not in self._updatable_attributes
             },
         ]
         return objects

--- a/aiida_test_cache/archive_cache/_utils.py
+++ b/aiida_test_cache/archive_cache/_utils.py
@@ -22,7 +22,7 @@ def rehash_processes() -> None:
     qub.append(ProcessNode)
     to_hash = qub.all()
     for node1 in to_hash:
-        node1[0].rehash()
+        node1[0].base.caching.rehash()
 
 
 def monkeypatch_hash_objects(

--- a/aiida_test_cache/mock_code/_fixtures.py
+++ b/aiida_test_cache/mock_code/_fixtures.py
@@ -114,8 +114,7 @@ def _forget_mpi_decorator(func):
 @pytest.fixture(scope='function')
 def mock_code_factory(
     aiida_localhost, testing_config, testing_config_action, mock_regenerate_test_data,
-    mock_fail_on_missing, mock_disable_mpi, monkeypatch, request: pytest.FixtureRequest,
-    tmp_path: pathlib.Path
+    mock_fail_on_missing, mock_disable_mpi, monkeypatch, request, tmp_path
 ):
     """
     Fixture to create a mock AiiDA Code.

--- a/docs/source/user_guide/archive_cache.rst
+++ b/docs/source/user_guide/archive_cache.rst
@@ -32,7 +32,7 @@ The workchain looks as follows
         return ToContext(diff_calc=running)
 
     def results(self):
-        computed_diff = self.ctx.diff_calc.get_outgoing().get_node_by_label('diff')
+        computed_diff = self.ctx.diff_calc.base.links.get_outgoing().get_node_by_label('diff')
         self.out('computed_diff', computed_diff)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,9 @@ aiida_archive_cache = "aiida_test_cache.archive_cache"
 
 [tool.pytest.ini_options]
 addopts = '--durations=10 --durations-min=3 --strict-config --strict-markers -ra --cov-report xml --cov-append'
-filterwarnings = []
+filterwarnings = [
+    'ignore:Creating AiiDA configuration:UserWarning:aiida',
+]
 
 [tool.yapf]
 based_on_style = "pep8"

--- a/tests/archive_cache/test_archive_cache.py
+++ b/tests/archive_cache/test_archive_cache.py
@@ -79,9 +79,7 @@ def check_diff_workchain_fixture():
 #### tests
 
 
-def test_create_node_archive(
-    mock_code_factory, generate_diff_inputs, aiida_profile_clean, tmp_path
-):
+def test_create_node_archive(mock_code_factory, generate_diff_inputs, clear_database, tmp_path):
     """
     Basic test of the create node archive fixture functionality,
     runs diff workchain and creates archive, check if archive was created
@@ -112,7 +110,7 @@ def test_create_node_archive(
     assert os.path.isfile(archive_path)
 
 
-def test_load_node_archive(aiida_profile_clean, absolute_archive_path):
+def test_load_node_archive(clear_database, absolute_archive_path):
     """Basic test of the load node archive fixture functionality, check if archive is loaded"""
 
     full_archive_path = absolute_archive_path('diff_workchain.tar.gz')
@@ -126,7 +124,7 @@ def test_load_node_archive(aiida_profile_clean, absolute_archive_path):
     assert n_nodes == 9
 
 
-def test_mock_hash_codes(mock_code_factory, aiida_profile_clean, liberal_hash):
+def test_mock_hash_codes(mock_code_factory, clear_database, liberal_hash):
     """test if mock of _get_objects_to_hash works for Code and Calcs"""
 
     mock_code = mock_code_factory(
@@ -147,7 +145,7 @@ def test_mock_hash_codes(mock_code_factory, aiida_profile_clean, liberal_hash):
 )
 def test_enable_archive_cache(
     archive_path, aiida_local_code_factory, generate_diff_inputs, enable_archive_cache,
-    aiida_profile_clean, check_diff_workchain
+    clear_database, check_diff_workchain
 ):
     """
     Basic test of the enable_archive_cache fixture
@@ -164,7 +162,7 @@ def test_enable_archive_cache(
 
 
 def test_enable_archive_cache_non_existent(
-    aiida_profile_clean, aiida_local_code_factory, generate_diff_inputs, enable_archive_cache,
+    aiida_local_code_factory, generate_diff_inputs, enable_archive_cache, clear_database,
     tmp_path_factory, check_diff_workchain
 ):
     """


### PR DESCRIPTION
Resolve warnings from AiiDA Node methods that were moved to `base` namespace in AiiDA v2. 

The main remaining deprecation is the `Code` class, which we should switch to `InstalledCode`. Will do that in a separate PR.

Also, switching from the deprecated `clear_database` fixture to `aiida_profile_clean` leads to four failing tests with errors like


> FAILED tests/archive_cache/test_archive_cache.py::test_create_node_archive - sqlalchemy.orm.exc.ObjectDeletedError: Instance '<DbComputer at 0x7fada78757e0>' has been deleted, or its row is otherwise not present.


Will deal with that separately.