### PR TITLE
Code -> InstalledCode

### DIFF
--- a/aiida_test_cache/archive_cache/_fixtures.py
+++ b/aiida_test_cache/archive_cache/_fixtures.py
@@ -17,6 +17,7 @@ from aiida.orm import (
     Code,
     Dict,
     FolderData,
+    InstalledCode,
     List,
     QueryBuilder,
     RemoteData,
@@ -296,6 +297,7 @@ def liberal_hash(monkeypatch: pytest.MonkeyPatch, testing_config: Config) -> Non
         return objects
 
     monkeypatch_hash_objects(monkeypatch, Code, mock_objects_to_hash_code)
+    monkeypatch_hash_objects(monkeypatch, InstalledCode, mock_objects_to_hash_code)
     monkeypatch_hash_objects(monkeypatch, CalcJobNode, mock_objects_to_hash_calcjob)
 
     nodes_to_patch = [Dict, SinglefileData, List, FolderData, RemoteData, StructureData]

--- a/aiida_test_cache/archive_cache/_fixtures.py
+++ b/aiida_test_cache/archive_cache/_fixtures.py
@@ -13,11 +13,10 @@ from aiida import plugins
 from aiida.common.links import LinkType
 from aiida.manage.caching import enable_caching
 from aiida.orm import (
+    AbstractCode,
     CalcJobNode,
-    Code,
     Dict,
     FolderData,
-    InstalledCode,
     List,
     QueryBuilder,
     RemoteData,
@@ -246,7 +245,7 @@ def liberal_hash(monkeypatch: pytest.MonkeyPatch, testing_config: Config) -> Non
 
     def mock_objects_to_hash_code(self):
         """
-        Return a list of objects which should be included in the hash of a Code node
+        Return a list of objects which should be included in the hash of a AbstractCode node
         """
         self = get_node_from_hash_objects_caller(self)
         # computer names are changed by aiida-core if imported and do not have same uuid.
@@ -296,8 +295,7 @@ def liberal_hash(monkeypatch: pytest.MonkeyPatch, testing_config: Config) -> Non
         ]
         return objects
 
-    monkeypatch_hash_objects(monkeypatch, Code, mock_objects_to_hash_code)
-    monkeypatch_hash_objects(monkeypatch, InstalledCode, mock_objects_to_hash_code)
+    monkeypatch_hash_objects(monkeypatch, AbstractCode, mock_objects_to_hash_code)
     monkeypatch_hash_objects(monkeypatch, CalcJobNode, mock_objects_to_hash_calcjob)
 
     nodes_to_patch = [Dict, SinglefileData, List, FolderData, RemoteData, StructureData]

--- a/aiida_test_cache/mock_code/_fixtures.py
+++ b/aiida_test_cache/mock_code/_fixtures.py
@@ -11,7 +11,7 @@ import uuid
 
 import click
 import pytest
-from aiida.orm import Code
+from aiida.orm import InstalledCode
 
 from .._config import CONFIG_FILE_NAME, Config, ConfigActions
 from ._env_keys import MockVariables
@@ -103,7 +103,7 @@ def testing_config(testing_config_action):
 
 
 def _forget_mpi_decorator(func):
-    """Modify :py:meth:`aiida.orm.Code.get_prepend_cmdline_params` to discard MPI parameters."""
+    """Modify :py:meth:`aiida.orm.InstalledCode.get_prepend_cmdline_params` to discard MPI parameters."""
 
     def _get_prepend_cmdline_params(self, mpi_args=None, extra_mpirun_params=None):  # noqa: ARG001
         return func(self)
@@ -117,7 +117,7 @@ def mock_code_factory(
     mock_fail_on_missing, mock_disable_mpi, monkeypatch, request, tmp_path
 ):
     """
-    Fixture to create a mock AiiDA Code.
+    Fixture to create a mock AiiDA InstalledCode.
 
     testing_config_action :
         Read config file if present ('read'), require config file ('require') or generate new config file ('generate').
@@ -225,9 +225,10 @@ def mock_code_factory(
 
         if _config_action == ConfigActions.GENERATE.value:
             mock_code_config[label] = code_executable_path
-        code = Code(
+        code = InstalledCode(
             input_plugin_name=entry_point,
-            remote_computer_exec=[aiida_localhost, mock_executable_path]
+            computer=aiida_localhost,
+            filepath_executable=mock_executable_path,
         )
         code.label = code_label
         variables = MockVariables(

--- a/docs/source/user_guide/mock_code.rst
+++ b/docs/source/user_guide/mock_code.rst
@@ -6,7 +6,7 @@ Using :mod:`.mock_code`
 
  1. A command-line script ``aiida-mock-code`` (the *mock executable*) that is executed instead of the *actual* executable and acts as a *cache* for the outputs of the actual executable
 
- 2. A pytest fixture :py:func:`~aiida_test_cache.mock_code.mock_code_factory` that sets up an AiiDA Code pointing to the mock executable
+ 2. A pytest fixture :py:func:`~aiida_test_cache.mock_code.mock_code_factory` that sets up an AiiDA InstalledCode pointing to the mock executable
 
 In the following, we will set up a mock code for the ``diff`` executable in three simple steps.
 
@@ -54,7 +54,7 @@ Second, we need to tell the mock executable where to find the *actual* ``diff`` 
    Finally, one could use dedicated environment variables to specify the locations of the executables, but there may be many of them, making this approach cumbersome.
    Ergo, a configuration file.
 
-Finally, we can use our fixture in our tests as if it would provide a normal :py:class:`~aiida.orm.Code`:
+Finally, we can use our fixture in our tests as if it would provide a normal :py:class:`~aiida.orm.InstalledCode`:
 
 .. code-block:: python
 


### PR DESCRIPTION
Use `InstalledCode` instead of the deprecated `Code` class. 

In the `archive_cache` fixture, monkeypatch `AbstractCode` class, which should take care of both `InstalledCode` and ` Code` since none of them have overriden the `get_objects_to_hash` function.