### PR TITLE
Remove rest of warnings in pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
-        aiida-version: ['2.5']
+        aiida-version-spec: ['>=2.5']
         # Include a job with minimum supported aiida-version
         include:
           - python-version: '3.9'
-            aiida-version: '2.1'
+            aiida-version-spec: '==2.1'
       fail-fast: false
 
     services:
@@ -55,7 +55,7 @@ jobs:
       with:
         version: ${{ env.UV_VER }}
     - name: Install package
-      run: uv pip install --system -e .[tests] aiida-core==${{ matrix.aiida-version }}
+      run: uv pip install --system -e .[tests] "aiida-core${{ matrix.aiida-version-spec }}"
 
     - name: Run test suite
       env:

--- a/aiida_test_cache/mock_code/_fixtures.py
+++ b/aiida_test_cache/mock_code/_fixtures.py
@@ -226,11 +226,11 @@ def mock_code_factory(
         if _config_action == ConfigActions.GENERATE.value:
             mock_code_config[label] = code_executable_path
         code = InstalledCode(
-            input_plugin_name=entry_point,
             computer=aiida_localhost,
+            default_calc_job_plugin=entry_point,
             filepath_executable=mock_executable_path,
+            label=code_label,
         )
-        code.label = code_label
         variables = MockVariables(
             log_file=log_file.absolute(),
             label=label,
@@ -242,7 +242,7 @@ def mock_code_factory(
             fail_on_missing=_fail_on_missing,
             _hasher=hasher,
         )
-        code.set_prepend_text(variables.to_env())
+        code.prepend_text = variables.to_env()
 
         code.store()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,10 @@ aiida_archive_cache = "aiida_test_cache.archive_cache"
 addopts = '--durations=10 --durations-min=3 --strict-config --strict-markers -ra --cov-report xml --cov-append'
 filterwarnings = [
     'ignore:Creating AiiDA configuration:UserWarning:aiida',
+    # https://github.com/aiidateam/plumpy/issues/283
+    'ignore:There is no current event loop:DeprecationWarning:plumpy',
+    # https://github.com/aiidateam/aiida-core/issues/6657
+    'ignore:Python 3.14 will, by default, filter extracted tar archives:DeprecationWarning:aiida',
 ]
 
 [tool.yapf]


### PR DESCRIPTION
Remove some remaining warnings related to `Code` deprecation. Followup to #93

The remaining warnings will be handled once we support AiiDA 2.6