### PR TITLE
CI: Use uv's resolution=lowest strategy in one of the jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,12 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
-        aiida-version-spec: ['>=2.5']
-        # Include a job with minimum supported aiida-version
+        resolution: ['highest']
+        # Include a job with minimum supported aiida-version,
+        # achieved via uv's resolution strategy
         include:
           - python-version: '3.9'
-            aiida-version-spec: '==2.1'
+            resolution: 'lowest-direct'
       fail-fast: false
 
     services:
@@ -55,7 +56,7 @@ jobs:
       with:
         version: ${{ env.UV_VER }}
     - name: Install package
-      run: uv pip install --system -e .[tests] "aiida-core${{ matrix.aiida-version-spec }}"
+      run: uv pip install --resolution ${{ matrix.resolution }} --system -e .[tests]
 
     - name: Run test suite
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
             - main
     pull_request:
 env:
-    UV_VER: "0.5.6"
+    UV_VER: "0.5.14"
     FORCE_COLOR: 1
 
 jobs:
@@ -53,7 +53,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v5
       with:
         version: ${{ env.UV_VER }}
     - name: Install package
@@ -87,7 +87,7 @@ jobs:
         python-version: '3.12'
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v5
       with:
         version: ${{ env.UV_VER }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12']
         resolution: ['highest']
         # Include a job with minimum supported aiida-version,
-        # achieved via uv's resolution strategy
+        # achieved via uv's resolution strategy, see:
+        # https://docs.astral.sh/uv/reference/settings/#resolution
         include:
           - python-version: '3.9'
             resolution: 'lowest-direct'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,8 @@ docs = ["sphinx", "sphinx-rtd-theme"]
 tests = [
     "pgtest~=1.3.1",
     "aiida-diff~=2.0.0",
-    "pytest-datadir",
-    "pytest-mock",
+    "pytest-datadir~=1.4",
+    "pytest-mock~=3.11",
     "pytest-cov>=4.0",
 ]
 pre_commit = [


### PR DESCRIPTION
This let's us test the lower bounds dependencies, in particular the lowest-supported aiida-core version. 
See https://docs.astral.sh/uv/reference/settings/#resolution