### PR TITLE
Switch to SQLite-based aiida-core fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
         resolution: ['highest']
         # Include a job with minimum supported aiida-version,
         # achieved via uv's resolution strategy, see:
@@ -25,12 +25,6 @@ jobs:
           - python-version: '3.9'
             resolution: 'lowest-direct'
       fail-fast: false
-
-    services:
-      rabbitmq:
-        image: rabbitmq:latest
-        ports:
-          - 5672:5672
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,19 +27,6 @@ jobs:
       fail-fast: false
 
     services:
-      postgres:
-        image: postgres:10
-        env:
-          POSTGRES_DB: test_aiida
-          POSTGRES_PASSWORD: ''
-          POSTGRES_HOST_AUTH_METHOD: trust
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
       rabbitmq:
         image: rabbitmq:latest
         ports:

--- a/aiida_test_cache/archive_cache/_utils.py
+++ b/aiida_test_cache/archive_cache/_utils.py
@@ -34,7 +34,7 @@ def monkeypatch_hash_objects(
     :param monkeypatch: monkeypatch fixture of pytest
     :param node_class: Node class to monkeypatch
     :param hash_objects_func: function, which should be called instead of the
-                              `_get_objects_to_hash` method
+                              `get_objects_to_hash` method
 
     .. note::
 
@@ -55,11 +55,6 @@ def monkeypatch_hash_objects(
             """
             NodeCaching subclass with stripped down _get_objects_to_hash method
             """
-
-            # Compatibility with aiida-core < 2.6
-            # In https://github.com/aiidateam/aiida-core/pull/6323
-            def _get_objects_to_hash(self):
-                return self.get_objects_to_hash()
 
             def get_objects_to_hash(self):
                 return hash_objects_func(self)

--- a/aiida_test_cache/archive_cache/_utils.py
+++ b/aiida_test_cache/archive_cache/_utils.py
@@ -29,7 +29,7 @@ def monkeypatch_hash_objects(
     monkeypatch: pytest.MonkeyPatch, node_class: type[Node], hash_objects_func: ty.Callable
 ) -> None:
     """
-    Monkeypatch the _get_objects_to_hash method in aiida-core for the given node class
+    Monkeypatch the get_objects_to_hash method in aiida-core for the given node class
 
     :param monkeypatch: monkeypatch fixture of pytest
     :param node_class: Node class to monkeypatch
@@ -49,7 +49,7 @@ def monkeypatch_hash_objects(
 
     class MockNodeCaching(node_class._CLS_NODE_CACHING):  # type: ignore[misc,name-defined]
         """
-        NodeCaching subclass with stripped down _get_objects_to_hash method
+        NodeCaching subclass with stripped down get_objects_to_hash method
         """
 
         def get_objects_to_hash(self):
@@ -61,12 +61,10 @@ def monkeypatch_hash_objects(
 def get_node_from_hash_objects_caller(caller: ty.Any) -> Node:
     """
     Get the actual node instance from the class calling the
-    _get_objects_to_hash method
+    get_objects_to_hash method
 
-    :param caller: object holding _get_objects_to_hash
+    :param caller: object holding get_objects_to_hash
     """
-    #Case for AiiDA 2.0: The class holding the _get_objects_to_hash method
-    #is the NodeCaching class not the actual node
     return caller._node  #type: ignore[no-any-return]
 
 

--- a/aiida_test_cache/archive_cache/_utils.py
+++ b/aiida_test_cache/archive_cache/_utils.py
@@ -46,20 +46,16 @@ def monkeypatch_hash_objects(
         monkeypatched on the Nodes, i.e. the _CLS_NODE_CACHING attribute
 
     """
-    try:
-        monkeypatch.setattr(node_class, "_get_objects_to_hash", hash_objects_func)
-    except AttributeError:
-        node_caching_class = node_class._CLS_NODE_CACHING
 
-        class MockNodeCaching(node_caching_class):  #type: ignore
-            """
-            NodeCaching subclass with stripped down _get_objects_to_hash method
-            """
+    class MockNodeCaching(node_class._CLS_NODE_CACHING):  # type: ignore[misc,name-defined]
+        """
+        NodeCaching subclass with stripped down _get_objects_to_hash method
+        """
 
-            def get_objects_to_hash(self):
-                return hash_objects_func(self)
+        def get_objects_to_hash(self):
+            return hash_objects_func(self)
 
-        monkeypatch.setattr(node_class, "_CLS_NODE_CACHING", MockNodeCaching)
+    monkeypatch.setattr(node_class, "_CLS_NODE_CACHING", MockNodeCaching)
 
 
 def get_node_from_hash_objects_caller(caller: ty.Any) -> Node:

--- a/aiida_test_cache/archive_cache/_utils.py
+++ b/aiida_test_cache/archive_cache/_utils.py
@@ -64,14 +64,6 @@ def monkeypatch_hash_objects(
             def get_objects_to_hash(self):
                 return hash_objects_func(self)
 
-            # Compatibility with aiida-core < 2.6
-            # https://github.com/aiidateam/aiida-core/pull/6347
-            def compute_hash(self):
-                try:
-                    return super().compute_hash()
-                except AttributeError:
-                    return super().get_hash()
-
         monkeypatch.setattr(node_class, "_CLS_NODE_CACHING", MockNodeCaching)
 
 

--- a/aiida_test_cache/mock_code/__init__.py
+++ b/aiida_test_cache/mock_code/__init__.py
@@ -17,4 +17,4 @@ __all__ = (
 )
 
 # ensure aiida's pytest plugin is loaded, which we rely on
-pytest_plugins = ['aiida.manage.tests.pytest_fixtures']
+pytest_plugins = ['aiida.tools.pytest_fixtures']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ keywords = [
 urls = {Homepage = "https://aiida-testing.readthedocs.io/"}
 requires-python = ">=3.9"
 dependencies = [
-    "aiida-core>=2.1,<3",
+    "aiida-core>=2.6,<3",
     "pytest>=7.0",
     "voluptuous~=0.12",
 ]

--- a/tests/archive_cache/test_archive_cache.py
+++ b/tests/archive_cache/test_archive_cache.py
@@ -137,7 +137,7 @@ def test_mock_hash_codes(aiida_profile_clean, mock_code_factory, liberal_hash):
         entry_point=CALC_ENTRY_POINT,
         ignore_paths=('_aiidasubmit.sh', 'file*')
     )
-    objs = mock_code.base.caching._get_objects_to_hash()
+    objs = mock_code.base.caching.get_objects_to_hash()
     assert objs == [mock_code.base.attributes.get(key='input_plugin')]
 
 

--- a/tests/archive_cache/test_archive_cache.py
+++ b/tests/archive_cache/test_archive_cache.py
@@ -81,7 +81,9 @@ def check_diff_workchain_fixture():
 #### tests
 
 
-def test_create_node_archive(mock_code_factory, generate_diff_inputs, clear_database, tmp_path):
+def test_create_node_archive(
+    aiida_profile_clean, mock_code_factory, generate_diff_inputs, tmp_path
+):
     """
     Basic test of the create node archive fixture functionality,
     runs diff workchain and creates archive, check if archive was created
@@ -112,7 +114,7 @@ def test_create_node_archive(mock_code_factory, generate_diff_inputs, clear_data
     assert os.path.isfile(archive_path)
 
 
-def test_load_node_archive(clear_database, absolute_archive_path):
+def test_load_node_archive(aiida_profile_clean, absolute_archive_path):
     """Basic test of the load node archive fixture functionality, check if archive is loaded"""
 
     full_archive_path = absolute_archive_path('diff_workchain.tar.gz')
@@ -126,7 +128,7 @@ def test_load_node_archive(clear_database, absolute_archive_path):
     assert n_nodes == 9
 
 
-def test_mock_hash_codes(mock_code_factory, clear_database, liberal_hash):
+def test_mock_hash_codes(aiida_profile_clean, mock_code_factory, liberal_hash):
     """test if mock of _get_objects_to_hash works for Code and Calcs"""
 
     mock_code = mock_code_factory(
@@ -140,18 +142,20 @@ def test_mock_hash_codes(mock_code_factory, clear_database, liberal_hash):
 
 
 @pytest.mark.parametrize(
-    "archive_path", [CWD / "caches/test_workchain.tar.gz", "test_workchain.tar.gz"]
+    'archive_path', [CWD / 'caches/test_workchain.tar.gz', 'test_workchain.tar.gz']
 )
 def test_enable_archive_cache(
-    archive_path, aiida_local_code_factory, generate_diff_inputs, enable_archive_cache,
-    clear_database, check_diff_workchain
+    archive_path, aiida_profile_clean, aiida_code_installed, generate_diff_inputs,
+    enable_archive_cache, check_diff_workchain
 ):
     """
     Basic test of the enable_archive_cache fixture
     """
 
     inputs = {'diff': generate_diff_inputs()}
-    diff_code = aiida_local_code_factory(executable='diff', entry_point='diff')
+    diff_code = aiida_code_installed(
+        filepath_executable='diff', default_calc_job_plugin=CALC_ENTRY_POINT
+    )
     diff_code.store()
     inputs['diff']['code'] = diff_code
     with enable_archive_cache(archive_path, calculation_class=CalculationFactory(CALC_ENTRY_POINT)):
@@ -161,7 +165,7 @@ def test_enable_archive_cache(
 
 
 def test_enable_archive_cache_non_existent(
-    aiida_local_code_factory, generate_diff_inputs, enable_archive_cache, clear_database,
+    aiida_profile_clean, aiida_code_installed, generate_diff_inputs, enable_archive_cache,
     tmp_path_factory, check_diff_workchain
 ):
     """
@@ -170,7 +174,9 @@ def test_enable_archive_cache_non_existent(
     """
 
     inputs = {'diff': generate_diff_inputs()}
-    diff_code = aiida_local_code_factory(executable='diff', entry_point='diff')
+    diff_code = aiida_code_installed(
+        filepath_executable='diff', default_calc_job_plugin=CALC_ENTRY_POINT
+    )
     diff_code.store()
     inputs['diff']['code'] = diff_code
 

--- a/tests/archive_cache/test_archive_cache.py
+++ b/tests/archive_cache/test_archive_cache.py
@@ -67,7 +67,7 @@ def check_diff_workchain_fixture():
         assert diffjob.base.caching.is_valid_cache
 
         calc_hash = diffjob.base.caching.get_hash()
-        assert calc_hash == EXPECTED_HASH, f'Hash mismatch. hashed objects: {diffjob.base.caching._get_objects_to_hash()}'
+        assert calc_hash == EXPECTED_HASH, f'Hash mismatch. hashed objects: {diffjob.base.caching.get_objects_to_hash()}'
 
         #Make sure that the cache was used if it should have been
         if should_have_used_cache:
@@ -129,7 +129,7 @@ def test_load_node_archive(aiida_profile_clean, absolute_archive_path):
 
 
 def test_mock_hash_codes(aiida_profile_clean, mock_code_factory, liberal_hash):
-    """test if mock of _get_objects_to_hash works for Code and Calcs"""
+    """test if mock of get_objects_to_hash works for Code and Calcs"""
 
     mock_code = mock_code_factory(
         label='diff',


### PR DESCRIPTION
This bumps minimum AiiDA version to 2.6.
The switch to SQLite is in the first commit, the rest is just cleaning up code that supported older AiiDA versions.

Alternative to #79 

Closes #79. Fixes #70 