### PR TITLE
CI: use `uv version` to simplify version check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
             - main
     pull_request:
 env:
-    UV_VER: "0.6.17"
+    UV_VER: "0.7.11"
     FORCE_COLOR: 1
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,6 +73,7 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
 
       # Remove the PR label which triggered this release,
       # but only if the release failed. Presumably, in this case we might want

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,9 @@ jobs:
   check-release-tag:
     name: Check tag version
     if: >-
-      github.repository == 'aiidateam/aiida-test-cache'
+      github.repository == 'aiidateam/aiida-test-cache' &&
+      github.event_name == 'push' &&
+      github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,13 +27,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+
+      - uses: astral-sh/setup-uv@v6
         with:
-          python-version: '3.12'
+          version: 0.7.11
+
       - name: Check version tag
         run: |
-          ver=$(python -c "from tomllib import load;p=load(open('pyproject.toml','rb'));print(p['project']['version'])")
+          ver=$(uv version --short)
           errormsg="tag version '${{ github.ref_name }}' != 'v$ver' specified in pyproject.toml"
           if [ "v${ver}" != "${{ github.ref_name }}" ]; then echo "$errormsg"; exit 1; fi
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,9 +21,7 @@ jobs:
   check-release-tag:
     name: Check tag version
     if: >-
-      github.repository == 'aiidateam/aiida-test-cache' &&
-      github.event_name == 'push' &&
-      github.ref_type == 'tag'
+      github.repository == 'aiidateam/aiida-test-cache'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
- use `uv version --short` to extract the package version from pyproject.toml (used in the publish.yml workflow to verify that the version specified by the tag corresponds to the package version)
- when publishing the TestPyPI, skip existing version of a package which allows the job step to succeed even though the upload itself did not do anything. One can thus test publishing to TestPyPI multiple times in the same PR.